### PR TITLE
Automatically find PATH to execute stdio process

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -31,17 +31,17 @@ jobs:
     - name: Run tests
       run: swift test -q --enable-code-coverage
     # Upload code coverage
-    - uses: michaelhenry/swifty-code-coverage@v1.0.0
-      with:
-        build-path: .build
-        target: MCPPackageTests.xctest
-        is-spm: true
-    - name: Upload to Codecov
-      run: |
-        bash <(curl https://codecov.io/bash) -f "coverage/*.info"
-      shell: bash
-      env:
-        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+    # - uses: michaelhenry/swifty-code-coverage@v1.0.0
+    #   with:
+    #     build-path: .build
+    #     target: MCPPackageTests.xctest
+    #     is-spm: true
+    # - name: Upload to Codecov
+    #   run: |
+    #     bash <(curl https://codecov.io/bash) -f "coverage/*.info"
+    #   shell: bash
+    #   env:
+    #     CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   lint:
     runs-on: macos-15

--- a/ExampleMCPClient/Sources/main.swift
+++ b/ExampleMCPClient/Sources/main.swift
@@ -1,0 +1,39 @@
+// swiftlint:disable no_direct_standard_out_logs
+import Foundation
+import MCPClient
+import MCPInterface
+
+let client = try await MCPClient(
+  info: .init(name: "test", version: "1.0.0"),
+  transport: .stdioProcess(
+    "uvx",
+    args: ["mcp-server-git"],
+    verbose: true),
+  capabilities: .init())
+
+let tools = await client.tools
+let tool = try tools.value.get().first(where: { $0.name == "git_status" })!
+print("git_status tool: \(tool)")
+
+// Those parameters can be passed to an LLM that support tool calling.
+let description = tool.description
+let name = tool.name
+let schemaData = try JSONEncoder().encode(tool.inputSchema)
+let schema = try JSONSerialization.jsonObject(with: schemaData)
+
+
+// The LLM could call into the tool with unstructured JSON input:
+let llmToolInput: [String: Any] = [
+  "repo_path": "/path/to/repo",
+]
+let llmToolInputData = try JSONSerialization.data(withJSONObject: llmToolInput)
+let toolInput = try JSONDecoder().decode(JSON.self, from: llmToolInputData)
+
+// Alternatively, you can call into the tool directly from Swift with structured input:
+// let toolInput: JSON = ["repo_path": .string("/path/to/repo")]
+
+let result = try await client.callTool(named: name, arguments: toolInput)
+if result.isError != true {
+  let content = result.content.first?.text?.text
+  print("Git status: \(content ?? "")")
+}

--- a/ExampleMCPClient/Sources/main.swift
+++ b/ExampleMCPClient/Sources/main.swift
@@ -21,8 +21,7 @@ let name = tool.name
 let schemaData = try JSONEncoder().encode(tool.inputSchema)
 let schema = try JSONSerialization.jsonObject(with: schemaData)
 
-
-// The LLM could call into the tool with unstructured JSON input:
+/// The LLM could call into the tool with unstructured JSON input:
 let llmToolInput: [String: Any] = [
   "repo_path": "/path/to/repo",
 ]

--- a/ExampleMCPClient/Sources/main.swift
+++ b/ExampleMCPClient/Sources/main.swift
@@ -3,6 +3,9 @@ import Foundation
 import MCPClient
 import MCPInterface
 
+/// Read the path from the process args
+let repoPath = CommandLine.arguments.count > 1 ? CommandLine.arguments[1] : "/path/to/repo"
+
 let client = try await MCPClient(
   info: .init(name: "test", version: "1.0.0"),
   transport: .stdioProcess(
@@ -23,13 +26,13 @@ let schema = try JSONSerialization.jsonObject(with: schemaData)
 
 /// The LLM could call into the tool with unstructured JSON input:
 let llmToolInput: [String: Any] = [
-  "repo_path": "/path/to/repo",
+  "repo_path": repoPath,
 ]
 let llmToolInputData = try JSONSerialization.data(withJSONObject: llmToolInput)
 let toolInput = try JSONDecoder().decode(JSON.self, from: llmToolInputData)
 
 // Alternatively, you can call into the tool directly from Swift with structured input:
-// let toolInput: JSON = ["repo_path": .string("/path/to/repo")]
+// let toolInput: JSON = ["repo_path": .string(repoPath)]
 
 let result = try await client.callTool(named: name, arguments: toolInput)
 if result.isError != true {

--- a/Package.swift
+++ b/Package.swift
@@ -22,6 +22,9 @@ let package = Package(
     .executable(name: "ExampleMCPServer", targets: [
       "ExampleMCPServer",
     ]),
+    .executable(name: "ExampleMCPClient", targets: [
+      "ExampleMCPClient",
+    ]),
   ],
   dependencies: [
     .package(url: "https://github.com/ChimeHQ/JSONRPC", revision: "ef61a695bafa0e07080dadac65a0c59b37880548"),
@@ -62,6 +65,12 @@ let package = Package(
         .target(name: "MCPServer"),
       ],
       path: "ExampleMCPServer/Sources"),
+    .executableTarget(
+      name: "ExampleMCPClient",
+      dependencies: [
+        .target(name: "MCPClient"),
+      ],
+      path: "ExampleMCPClient/Sources"),
 
     // Tests libraries
     .target(


### PR DESCRIPTION
## Summary
Automatically find PATH to execute stdio process.

## Details
When running from a MacOC app, the process environment is not the same as when running an executable from the terminal. Consequently, the PATH is likely to not contain the desired executables (`npx`, `uvx` etc).
-> When the executable is unknown in the current environment, try to load the environment that is the default with `zsh`, ie `/bin/zsh -c source ~/.zshrc && printenv`

Also added a small example of how to use an MCP client.

## Checklist before merging
- [ ] If this is a new feature or a bug fix, I have added tests.
