### PR TITLE
Rework lint

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -47,7 +47,12 @@ jobs:
     runs-on: macos-15
     steps:
     - uses: actions/checkout@v4
+    - name: Set up Homebrew
+      id: set-up-homebrew
+      uses: Homebrew/actions/setup-homebrew@master
+    - name: Install swiftformat
+      run: brew install swiftformat
     - name: Run linter
-      run: swift package --allow-writing-to-package-directory format
+      run: swiftformat --config rules.swiftformat .
     - name: Verify that `swift package --allow-writing-to-package-directory format` did not change outputs (if it did, please re-run it and re-commit!)
       run: git diff --exit-code

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -54,5 +54,5 @@ jobs:
       run: brew install swiftformat
     - name: Run linter
       run: swiftformat --config rules.swiftformat .
-    - name: Verify that `swift package --allow-writing-to-package-directory format` did not change outputs (if it did, please re-run it and re-commit!)
+    - name: Verify that `swiftformat --config rules.swiftformat .` did not change outputs (if it did, please re-run it and re-commit!)
       run: git diff --exit-code

--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,5 @@ fastlane/report.xml
 fastlane/Preview.html
 fastlane/screenshots/**/*.png
 fastlane/test_output
+.DS_Store
+.vscode

--- a/MCPClient/Sources/MCPClientConnection.swift
+++ b/MCPClient/Sources/MCPClientConnection.swift
@@ -7,8 +7,6 @@ import MemberwiseInit
 
 public actor MCPClientConnection: MCPClientConnectionInterface {
 
-  // MARK: Lifecycle
-
   public init(
     info: Implementation,
     capabilities: ClientCapabilities,
@@ -20,8 +18,6 @@ public actor MCPClientConnection: MCPClientConnectionInterface {
     self.info = info
     self.capabilities = capabilities
   }
-
-  // MARK: Public
 
   public let info: Implementation
 
@@ -107,8 +103,6 @@ public actor MCPClientConnection: MCPClientConnectionInterface {
   public func notifyRootsListChanged() async throws {
     try await jrpcSession.send(RootsListChangedNotification())
   }
-
-  // MARK: Private
 
   private let _connection: MCPConnection<ServerRequest, ServerNotification>
 

--- a/MCPClient/Sources/MCPClientInterface.swift
+++ b/MCPClient/Sources/MCPClientInterface.swift
@@ -65,9 +65,9 @@ extension MCPClientError: LocalizedError {
   public var errorDescription: String? {
     switch self {
     case .versionMismatch(let received, let expected):
-      return "Version mismatch between server and client. Received: \(received), Expected: \(expected)"
+      "Version mismatch between server and client. Received: \(received), Expected: \(expected)"
     case .toolCallError(let executionErrors):
-      return "Error executing tool:\n\(executionErrors.map { $0.errorDescription ?? "unknown error" }.joined(separator: "\n\n"))"
+      "Error executing tool:\n\(executionErrors.map { $0.errorDescription ?? "unknown error" }.joined(separator: "\n\n"))"
     }
   }
 }

--- a/MCPClient/Sources/Process+extensions.swift
+++ b/MCPClient/Sources/Process+extensions.swift
@@ -35,12 +35,12 @@ extension Process {
   func finish() throws {
     /// The full path to the executable + all arguments, each one quoted if it contains a space.
     func commandAsString() -> String {
-      let path: String
-      if #available(OSX 10.13, *) {
-        path = self.executableURL?.path ?? ""
-      } else {
-        path = launchPath ?? ""
-      }
+      let path: String =
+        if #available(OSX 10.13, *) {
+          self.executableURL?.path ?? ""
+        } else {
+          launchPath ?? ""
+        }
       return (arguments ?? []).reduce(path) { (acc: String, arg: String) in
         acc + " " + (arg.contains(" ") ? ("\"" + arg + "\"") : arg)
       }
@@ -66,9 +66,9 @@ enum CommandError: Error, Equatable {
   public var errorcode: Int {
     switch self {
     case .returnedErrorCode(_, let code):
-      return code
+      code
     case .inAccessibleExecutable:
-      return 127 // according to http://tldp.org/LDP/abs/html/exitcodes.html
+      127 // according to http://tldp.org/LDP/abs/html/exitcodes.html
     }
   }
 }
@@ -79,9 +79,9 @@ extension CommandError: CustomStringConvertible {
   public var description: String {
     switch self {
     case .inAccessibleExecutable(let path):
-      return "Could not execute file at path '\(path)'."
+      "Could not execute file at path '\(path)'."
     case .returnedErrorCode(let command, let code):
-      return "Command '\(command)' returned with error code \(code)."
+      "Command '\(command)' returned with error code \(code)."
     }
   }
 }

--- a/MCPClient/Sources/stdioTransport/DataChannel+StdioProcess.swift
+++ b/MCPClient/Sources/stdioTransport/DataChannel+StdioProcess.swift
@@ -23,29 +23,27 @@ extension JSONRPCSetupError: LocalizedError {
   public var errorDescription: String? {
     switch self {
     case .missingStandardIO:
-      return "Missing standard IO"
+      "Missing standard IO"
     case .couldNotLocateExecutable(let executable, let error):
-      return "Could not locate executable \(executable) \(error ?? "")".trimmingCharacters(in: .whitespaces)
+      "Could not locate executable \(executable) \(error ?? "")".trimmingCharacters(in: .whitespaces)
     case .standardIOConnectionError(let message):
-      return "Could not connect to stdio: \(message)".trimmingCharacters(in: .whitespaces)
+      "Could not connect to stdio: \(message)".trimmingCharacters(in: .whitespaces)
     }
   }
 
   public var recoverySuggestion: String? {
     switch self {
     case .missingStandardIO:
-      return "Make sure that the Process that is passed as an argument has stdin, stdout and stderr set as a Pipe."
+      "Make sure that the Process that is passed as an argument has stdin, stdout and stderr set as a Pipe."
     case .couldNotLocateExecutable:
-      return "Check that the executable is findable given the PATH environment variable. If needed, pass the right environment to the process."
+      "Check that the executable is findable given the PATH environment variable. If needed, pass the right environment to the process."
     case .standardIOConnectionError:
-      return nil
+      nil
     }
   }
 }
 
 extension Transport {
-
-  // MARK: Public
 
   /// Creates a new `Transport` by launching the given executable with the specified arguments and attaching to its standard IO.
   public static func stdioProcess(
@@ -193,8 +191,6 @@ extension Transport {
     return Transport(writeHandler: writeHandler, dataSequence: outStream)
   }
 
-  // MARK: Private
-
   /// Finds the full path to the executable using the `which` command.
   private static func locate(executable: String, env: [String: String]? = nil) throws -> String {
     let process = Process()
@@ -266,8 +262,6 @@ extension Transport {
 
 final class Lifetime {
 
-  // MARK: Lifecycle
-
   init(onDeinit: @escaping () -> Void) {
     self.onDeinit = onDeinit
   }
@@ -275,8 +269,6 @@ final class Lifetime {
   deinit {
     onDeinit()
   }
-
-  // MARK: Private
 
   private let onDeinit: () -> Void
 

--- a/MCPClient/Tests/Initialization.swift
+++ b/MCPClient/Tests/Initialization.swift
@@ -95,7 +95,7 @@ extension MCPClientTestSuite {
             """),
         ])
 
-      let clientCapabilities = await(client.connection as? MCPClientConnection)?.capabilities
+      let clientCapabilities = await (client.connection as? MCPClientConnection)?.capabilities
       #expect(clientCapabilities?.roots?.listChanged == true)
       #expect(clientCapabilities?.sampling != nil)
     }

--- a/MCPClient/Tests/MCPClientTests.swift
+++ b/MCPClient/Tests/MCPClientTests.swift
@@ -12,8 +12,6 @@ class MCPClientTestSuite { }
 
 class MCPClientTest {
 
-  // MARK: Lifecycle
-
   init() {
     version = "1.0.0"
     name = "TestClient"
@@ -41,8 +39,6 @@ class MCPClientTest {
     connection.listResourcesStub = { [] }
     connection.listResourceTemplatesStub = { [] }
   }
-
-  // MARK: Internal
 
   let version: String
   let capabilities: ClientCapabilities

--- a/MCPClient/Tests/MockMCPClientConnection.swift
+++ b/MCPClient/Tests/MockMCPClientConnection.swift
@@ -7,8 +7,6 @@ import MCPInterface
 /// A mock `MCPClientConnection` that can be used in tests.
 class MockMCPClientConnection: MCPClientConnectionInterface {
 
-  // MARK: Lifecycle
-
   required init(info: Implementation, capabilities: ClientCapabilities, transport _: Transport = .noop) throws {
     self.info = info
     self.capabilities = capabilities
@@ -25,8 +23,6 @@ class MockMCPClientConnection: MCPClientConnectionInterface {
     }
     self.sendRequestToStream = sendRequestToStream
   }
-
-  // MARK: Internal
 
   /// Send a server notification.
   private(set) var sendNotificationToStream: ((ServerNotification) -> Void) = { _ in }

--- a/MCPClient/Tests/ServerRequests.swift
+++ b/MCPClient/Tests/ServerRequests.swift
@@ -24,7 +24,7 @@ extension MCPClientTestSuite {
         do {
           let success = try response.get()
           let roots = try #require(success as? ListRootsResult)
-          #expect(roots.roots.map { $0.uri } == ["//root"])
+          #expect(roots.roots.map(\.uri) == ["//root"])
           expectation.fulfill()
         } catch {
           Issue.record(error)

--- a/MCPClientChatDemo/MCPClientChat/MCPClientChat/Chat/Models/AnthropicNonStreamManager.swift
+++ b/MCPClientChatDemo/MCPClientChat/MCPClientChat/Chat/Models/AnthropicNonStreamManager.swift
@@ -12,18 +12,14 @@ import MCPInterface
 import SwiftAnthropic
 import SwiftUI
 
+/// Handle a chat conversation without stream.
 @MainActor
 @Observable
-/// Handle a chat conversation without stream.
 final class AnthropicNonStreamManager: ChatManager {
-
-  // MARK: Lifecycle
 
   init(service: AnthropicService) {
     self.service = service
   }
-
-  // MARK: Internal
 
   /// Messages sent from the user or received from Claude
   var messages = [ChatMessage]()
@@ -65,8 +61,6 @@ final class AnthropicNonStreamManager: ChatManager {
     task?.cancel()
     task = nil
   }
-
-  // MARK: Private
 
   /// Service to communicate with Anthropic API
   private let service: AnthropicService

--- a/MCPClientChatDemo/MCPClientChat/MCPClientChat/Chat/Models/OpenAIChatNonStreamManager.swift
+++ b/MCPClientChatDemo/MCPClientChat/MCPClientChat/Chat/Models/OpenAIChatNonStreamManager.swift
@@ -12,18 +12,14 @@ import MCPInterface
 import SwiftOpenAI
 import SwiftUI
 
+/// Handle a chat conversation without stream for OpenAI.
 @MainActor
 @Observable
-/// Handle a chat conversation without stream for OpenAI.
 final class OpenAIChatNonStreamManager: ChatManager {
-
-  // MARK: Lifecycle
 
   init(service: OpenAIService) {
     self.service = service
   }
-
-  // MARK: Internal
 
   /// Messages sent from the user or received from OpenAI
   var messages = [ChatMessage]()
@@ -65,8 +61,6 @@ final class OpenAIChatNonStreamManager: ChatManager {
     task?.cancel()
     task = nil
   }
-
-  // MARK: Private
 
   /// Service to communicate with OpenAI API
   private let service: OpenAIService

--- a/MCPClientChatDemo/MCPClientChat/MCPClientChat/Chat/UI/ChatInputView.swift
+++ b/MCPClientChatDemo/MCPClientChat/MCPClientChat/Chat/UI/ChatInputView.swift
@@ -10,8 +10,6 @@ import SwiftUI
 /// A view for the user to enter chat messages
 struct ChatInputView: View {
 
-  // MARK: Internal
-
   /// Is a streaming chat response in progress
   let isStreamingResponse: Bool
 
@@ -28,8 +26,6 @@ struct ChatInputView: View {
     }
     .padding(8)
   }
-
-  // MARK: Private
 
   private enum FocusedField {
     case newMessageText

--- a/MCPClientChatDemo/MCPClientChat/MCPClientChat/Chat/UI/ChatMessageView.swift
+++ b/MCPClientChatDemo/MCPClientChat/MCPClientChat/Chat/UI/ChatMessageView.swift
@@ -10,8 +10,6 @@ import SwiftUI
 
 struct ChatMessageView: View {
 
-  // MARK: Internal
-
   /// The message to display
   let message: ChatMessage
 
@@ -32,8 +30,6 @@ struct ChatMessageView: View {
       adjustAnimationTriggerIfNecessary()
     }
   }
-
-  // MARK: Private
 
   /// State used to animate in the chat bubble if `animateIn` is true
   @State private var animationTrigger = false

--- a/MCPClientChatDemo/MCPClientChat/MCPClientChat/Chat/UI/ChatView.swift
+++ b/MCPClientChatDemo/MCPClientChat/MCPClientChat/Chat/UI/ChatView.swift
@@ -13,8 +13,6 @@ import SwiftUI
 @MainActor
 struct ChatView: View {
 
-  // MARK: Internal
-
   let chatManager: ChatManager
 
   var body: some View {
@@ -30,8 +28,6 @@ struct ChatView: View {
         didTapStop: { chatManager.stop() })
     }
   }
-
-  // MARK: Private
 
   private func sendMessage(_ message: String) {
     guard !message.isEmpty else { return }

--- a/MCPClientChatDemo/MCPClientChat/MCPClientChat/MCP/Clients/GithubMCPClient.swift
+++ b/MCPClientChatDemo/MCPClientChat/MCPClientChat/MCP/Clients/GithubMCPClient.swift
@@ -13,8 +13,6 @@ import SwiftUI
 
 final class GIthubMCPClient {
 
-  // MARK: Lifecycle
-
   init() {
     Task {
       do {
@@ -35,8 +33,6 @@ final class GIthubMCPClient {
     }
   }
 
-  // MARK: Internal
-
   /// Modern async/await approach
   func getClientAsync() async throws -> MCPClient? {
     for await client in clientInitialized.stream {
@@ -44,8 +40,6 @@ final class GIthubMCPClient {
     }
     return nil // Stream completed without a client
   }
-
-  // MARK: Private
 
   private var client: MCPClient?
   private let clientInitialized = AsyncStream.makeStream(of: MCPClient?.self)

--- a/MCPClientChatDemo/MCPClientChat/MCPClientChat/MCP/Tools/MCPTool+AnthropicTool.swift
+++ b/MCPClientChatDemo/MCPClientChat/MCPClientChat/MCP/Tools/MCPTool+AnthropicTool.swift
@@ -12,8 +12,6 @@ import SwiftAnthropic
 
 extension MCPInterface.Tool {
 
-  // MARK: Public
-
   /// Converts an MCP interface tool to SwiftAnthropic's tool format.
   ///
   /// This function transforms the tool's metadata and schema structure from
@@ -24,15 +22,14 @@ extension MCPInterface.Tool {
   ///   functionality as the original MCP tool.
   public func toAnthropicTool() -> SwiftAnthropic.MessageParameter.Tool {
     // Convert the JSON to SwiftAnthropic.JSONSchema
-    let anthropicInputSchema: SwiftAnthropic.MessageParameter.Tool.JSONSchema?
-
-    switch inputSchema {
-    case .object(let value):
-      anthropicInputSchema = convertToAnthropicJSONSchema(from: value)
-    case .array:
-      // Arrays are not directly supported in the schema root
-      anthropicInputSchema = nil
-    }
+    let anthropicInputSchema: SwiftAnthropic.MessageParameter.Tool.JSONSchema? =
+      switch inputSchema {
+      case .object(let value):
+        convertToAnthropicJSONSchema(from: value)
+      case .array:
+        // Arrays are not directly supported in the schema root
+        nil
+      }
 
     return SwiftAnthropic.MessageParameter.Tool(
       name: name,
@@ -40,8 +37,6 @@ extension MCPInterface.Tool {
       inputSchema: anthropicInputSchema,
       cacheControl: nil)
   }
-
-  // MARK: Private
 
   /// Converts MCP JSON object to SwiftAnthropic JSONSchema format.
   ///
@@ -474,19 +469,19 @@ extension MessageResponse.Content.DynamicContent {
   func extractValue() -> Any {
     switch self {
     case .string(let value):
-      return value
+      value
     case .integer(let value):
-      return value
+      value
     case .double(let value):
-      return value
+      value
     case .dictionary(let value):
-      return value.mapValues { $0.extractValue() }
+      value.mapValues { $0.extractValue() }
     case .array(let value):
-      return value.map { $0.extractValue() }
+      value.map { $0.extractValue() }
     case .bool(let value):
-      return value
+      value
     case .null:
-      return NSNull()
+      NSNull()
     }
   }
 }

--- a/MCPClientChatDemo/MCPClientChat/MCPClientChat/MCP/Tools/MCPTool+OpenAITool.swift
+++ b/MCPClientChatDemo/MCPClientChat/MCPClientChat/MCP/Tools/MCPTool+OpenAITool.swift
@@ -12,8 +12,6 @@ import SwiftOpenAI
 
 extension MCPInterface.Tool {
 
-  // MARK: Public
-
   /// Converts an MCP interface tool to SwiftOpenAI's tool format.
   ///
   /// This function transforms the tool's metadata and schema structure from
@@ -24,15 +22,14 @@ extension MCPInterface.Tool {
   ///   functionality as the original MCP tool.
   public func toOpenAITool() -> SwiftOpenAI.ChatCompletionParameters.Tool {
     // Convert the JSON to SwiftOpenAI.JSONSchema
-    let openAIParameters: SwiftOpenAI.JSONSchema?
-
-    switch inputSchema {
-    case .object(let value):
-      openAIParameters = convertToOpenAIJSONSchema(from: value)
-    case .array:
-      // Arrays are not directly supported in the schema root
-      openAIParameters = nil
-    }
+    let openAIParameters: SwiftOpenAI.JSONSchema? =
+      switch inputSchema {
+      case .object(let value):
+        convertToOpenAIJSONSchema(from: value)
+      case .array:
+        // Arrays are not directly supported in the schema root
+        nil
+      }
 
     let chatFunction = SwiftOpenAI.ChatCompletionParameters.ChatFunction(
       name: name,
@@ -44,8 +41,6 @@ extension MCPInterface.Tool {
       type: "function", // Currently only "function" is supported
       function: chatFunction)
   }
-
-  // MARK: Private
 
   /// Converts MCP JSON object to SwiftOpenAI JSONSchema format.
   ///
@@ -164,7 +159,7 @@ extension MCPInterface.Tool {
 
     // Fix for OpenAI's requirement: for strict schemas, include all property keys in required array
     // If we're dealing with an object type and have properties
-    if type == .object && properties != nil {
+    if type == .object, properties != nil {
       // Initialize the set of all property keys
       var allPropertyKeys = Set(properties!.keys)
 

--- a/MCPClientChatDemo/MCPClientChat/MCPClientChat/MCPClientChatApp.swift
+++ b/MCPClientChatDemo/MCPClientChat/MCPClientChat/MCPClientChatApp.swift
@@ -12,8 +12,6 @@ import SwiftUI
 @main
 struct MCPClientChatApp: App {
 
-  // MARK: Lifecycle
-
   init() {
     let service = AnthropicServiceFactory.service(apiKey: "", betaHeaders: nil, debugEnabled: true)
 
@@ -29,8 +27,6 @@ struct MCPClientChatApp: App {
     //
     //      _chatManager = State(initialValue: openAIChatNonStreamManager)
   }
-
-  // MARK: Internal
 
   var body: some Scene {
     WindowGroup {
@@ -49,8 +45,7 @@ struct MCPClientChatApp: App {
     .windowStyle(.hiddenTitleBar)
   }
 
-  // MARK: Private
-
   @State private var chatManager: ChatManager
+
   private let githubClient = GIthubMCPClient()
 }

--- a/MCPInterface/Sources/Interfaces.swift
+++ b/MCPInterface/Sources/Interfaces.swift
@@ -69,7 +69,7 @@ extension MCPError: LocalizedError {
   public var errorDescription: String? {
     switch self {
     case .capabilityNotSupported:
-      return "The requested capability is not supported"
+      "The requested capability is not supported"
     }
   }
 }

--- a/MCPInterface/Sources/MCPConnection.swift
+++ b/MCPInterface/Sources/MCPConnection.swift
@@ -8,8 +8,6 @@ public typealias HandleRequest<Request> = (Request, (AnyJRPCResponse) -> Void)
 /// Note: this class is not thread safe, and should be used in a thread safe context (like within an actor).
 package class MCPConnection<Request: Decodable & Equatable, Notification: Decodable & Equatable> {
 
-  // MARK: Lifecycle
-
   public init(
     transport: Transport)
     throws
@@ -40,16 +38,10 @@ package class MCPConnection<Request: Decodable & Equatable, Notification: Decoda
     Task { await listenToIncomingMessages() }
   }
 
-  // MARK: Public
-
   public private(set) var notifications: AsyncStream<Notification>
   public private(set) var requestsToHandle: AsyncStream<HandleRequest<Request>>
 
-  // MARK: Package
-
   package let jrpcSession: JSONRPCSession
-
-  // MARK: Private
 
   private var sendNotificationToStream: ((Notification) -> Void) = { _ in }
 

--- a/MCPInterface/Sources/ReadOnlyCurrentValueSubject.swift
+++ b/MCPInterface/Sources/ReadOnlyCurrentValueSubject.swift
@@ -6,8 +6,6 @@ import Combine
 /// Like `CurrentValueSubject`, but read-only other than for its owner.
 public class ReadOnlyCurrentValueSubject<Output, Failure>: Publisher where Failure: Error {
 
-  // MARK: Lifecycle
-
   public init(_ value: Output, setValue: @escaping ((Output) -> Void) -> Void) {
     currentValueSubject = .init(value)
     setValue { [weak self] in
@@ -33,8 +31,6 @@ public class ReadOnlyCurrentValueSubject<Output, Failure>: Publisher where Failu
     self.cancellable = cancellable
   }
 
-  // MARK: Public
-
   public private(set) var value: Output {
     get { currentValueSubject.value }
     set { currentValueSubject.value = newValue }
@@ -43,8 +39,6 @@ public class ReadOnlyCurrentValueSubject<Output, Failure>: Publisher where Failu
   public func receive<S>(subscriber: S) where S: Subscriber, Failure == S.Failure, Output == S.Input {
     currentValueSubject.receive(subscriber: subscriber)
   }
-
-  // MARK: Private
 
   private var cancellable: AnyCancellable?
 

--- a/MCPInterface/Sources/helpers/JSON+Streaming.swift
+++ b/MCPInterface/Sources/helpers/JSON+Streaming.swift
@@ -24,8 +24,6 @@ extension AsyncStream<Data> {
 
 extension Data {
 
-  // MARK: Internal
-
   /// Given a Data object that represents one or several valid JSON objects concatenated together, with the last one possibly truncated,
   /// return a list of Data objects, each representing a valid JSON object, as well as the optional truncated data.
   func parseJSONObjects() -> (objects: [Data], truncatedData: Data?) {
@@ -70,17 +68,15 @@ extension Data {
       }
     }
 
-    let truncatedData: Data?
-    if let lastChunkStartIndex = currentChunkStartIndex {
-      truncatedData = self[startIndex.advanced(by: lastChunkStartIndex) ..< startIndex.advanced(by: count)]
-    } else {
-      truncatedData = nil
-    }
+    let truncatedData: Data? =
+      if let lastChunkStartIndex = currentChunkStartIndex {
+        self[startIndex.advanced(by: lastChunkStartIndex) ..< startIndex.advanced(by: count)]
+      } else {
+        nil
+      }
 
     return (objects: objects, truncatedData: truncatedData)
   }
-
-  // MARK: Private
 
   private static let openBrace = UInt8(ascii: "{")
   private static let closeBrace = UInt8(ascii: "}")

--- a/MCPInterface/Sources/mcp_interfaces/JSON+extensions.swift
+++ b/MCPInterface/Sources/mcp_interfaces/JSON+extensions.swift
@@ -3,8 +3,6 @@ import Foundation
 
 extension JSON {
 
-  // MARK: Lifecycle
-
   public init(from decoder: Decoder) throws {
     do {
       // Object
@@ -29,8 +27,6 @@ extension JSON {
     }
   }
 
-  // MARK: Public
-
   public static func ==(lhs: JSON, rhs: JSON) -> Bool {
     lhs.asValue == rhs.asValue
   }
@@ -38,8 +34,6 @@ extension JSON {
   public func encode(to encoder: any Encoder) throws {
     try asValue.encode(to: encoder)
   }
-
-  // MARK: Internal
 
   var asValue: JSON.Value {
     switch self {
@@ -53,8 +47,6 @@ extension JSON {
 }
 
 extension JSON.Value {
-
-  // MARK: Lifecycle
 
   public init(from decoder: Decoder) throws {
     do {
@@ -95,8 +87,6 @@ extension JSON.Value {
       }
     }
   }
-
-  // MARK: Public
 
   public static func ==(lhs: JSON.Value, rhs: JSON.Value) -> Bool {
     switch (lhs, rhs) {
@@ -160,7 +150,7 @@ extension JSON {
       }
 
     case .array(let value):
-      value.map { $0.asAny }
+      value.map(\.asAny)
     }
   }
 
@@ -169,7 +159,7 @@ extension JSON {
   }
 
   public func asJSONString(options: JSONSerialization.WritingOptions = []) throws -> String {
-    guard let string = String(data: try asJSONData(options: options), encoding: .utf8) else {
+    guard let string = try String(data: asJSONData(options: options), encoding: .utf8) else {
       throw NSError(domain: "JSON", code: 0, userInfo: [NSLocalizedDescriptionKey: "Failed to convert JSON to string"])
     }
     return string
@@ -188,7 +178,7 @@ extension JSON.Value {
       }
 
     case .array(let value):
-      value.map { $0.asAny }
+      value.map(\.asAny)
 
     case .bool(let value):
       value
@@ -206,8 +196,6 @@ extension JSON.Value {
 
 extension String: @retroactive CodingKey {
 
-  // MARK: Lifecycle
-
   public init?(stringValue: String) {
     self = stringValue
   }
@@ -215,8 +203,6 @@ extension String: @retroactive CodingKey {
   public init?(intValue: Int) {
     self = "\(intValue)"
   }
-
-  // MARK: Public
 
   public var stringValue: String { self }
   public var intValue: Int? { Int(self) }

--- a/MCPInterface/Tests/interface/AnyMetaTests.swift
+++ b/MCPInterface/Tests/interface/AnyMetaTests.swift
@@ -7,8 +7,6 @@ extension MCPInterfaceTests {
   enum AnyMetaTest {
     struct Serialization {
 
-      // MARK: Internal
-
       @Test
       func encodeWithNoValues() throws {
         try testEncoding(of: AnyMeta(.object([:])), """
@@ -31,16 +29,12 @@ extension MCPInterfaceTests {
           """)
       }
 
-      // MARK: Private
-
       private func testEncoding(of value: AnyMeta, _ json: String) throws {
         try testEncodingOf(value, json)
       }
     }
 
     struct Deserialization {
-
-      // MARK: Internal
 
       @Test
       func decodeWithNoValues() throws {
@@ -63,8 +57,6 @@ extension MCPInterfaceTests {
           "bar": .bool(true),
         ])))
       }
-
-      // MARK: Private
 
       private func testDecoding(of jsonString: String, _ value: AnyMeta) throws {
         let data = jsonString.data(using: .utf8)!

--- a/MCPInterface/Tests/interface/AnyParamsTests.swift
+++ b/MCPInterface/Tests/interface/AnyParamsTests.swift
@@ -7,8 +7,6 @@ extension MCPInterfaceTests {
   enum AnyParamsTest {
     struct Serialization {
 
-      // MARK: Internal
-
       @Test
       func encodeWithNoValues() throws {
         try testEncoding(of: AnyParams(), """
@@ -58,16 +56,12 @@ extension MCPInterfaceTests {
             """)
       }
 
-      // MARK: Private
-
       private func testEncoding(of value: AnyParams, _ json: String) throws {
         try testEncodingOf(value, json)
       }
     }
 
     struct Deserialization {
-
-      // MARK: Internal
 
       @Test
       func decodeWithNoValues() throws {
@@ -117,8 +111,6 @@ extension MCPInterfaceTests {
             "key": .string("value"),
           ]))
       }
-
-      // MARK: Private
 
       private func testDecoding(of json: String, _ expected: AnyParams) throws {
         let data = json.data(using: .utf8)!

--- a/MCPInterface/Tests/interface/ClientNotificationTests.swift
+++ b/MCPInterface/Tests/interface/ClientNotificationTests.swift
@@ -8,8 +8,6 @@ extension MCPInterfaceTests {
 
     struct Deserialization {
 
-      // MARK: Internal
-
       @Test
       func decodeCancelledNotification() throws {
         try testDecoding(
@@ -77,8 +75,6 @@ extension MCPInterfaceTests {
           """.data(using: .utf8)!
         #expect(throws: DecodingError.self) { try JSONDecoder().decode(ClientNotification.self, from: data) }
       }
-
-      // MARK: Private
 
       private func testDecoding(of json: String, _ value: ClientNotification) throws {
         let data = json.data(using: .utf8)!

--- a/MCPInterface/Tests/interface/ClientRequestTests.swift
+++ b/MCPInterface/Tests/interface/ClientRequestTests.swift
@@ -7,8 +7,6 @@ extension MCPInterfaceTests {
 
     struct Deserialization {
 
-      // MARK: Internal
-
       @Test
       func decodeInitializeRequest() throws {
         try testDecoding(
@@ -218,8 +216,6 @@ extension MCPInterfaceTests {
             """,
           .setLogLevel(.init(level: .debug)))
       }
-
-      // MARK: Private
 
       private func testDecoding(of json: String, _ value: ClientRequest) throws {
         let data = json.data(using: .utf8)!

--- a/MCPInterface/Tests/interface/LoggingLevelTests.swift
+++ b/MCPInterface/Tests/interface/LoggingLevelTests.swift
@@ -6,8 +6,6 @@ extension MCPInterfaceTests {
   enum LoggingLevelTest {
     struct Serialization {
 
-      // MARK: Internal
-
       @Test
       func encodeDebug() throws {
         try testEncoding(of: .debug, "\"debug\"")
@@ -48,8 +46,6 @@ extension MCPInterfaceTests {
         try testEncoding(of: .emergency, "\"emergency\"")
       }
 
-      // MARK: Private
-
       private func testEncoding(of value: LoggingLevel, _ json: String) throws {
         // wrap the value in array for it to be valid JSON
         try testEncodingOf([value], "[\(json)]")
@@ -57,8 +53,6 @@ extension MCPInterfaceTests {
     }
 
     struct Deserialization {
-
-      // MARK: Internal
 
       @Test
       func decodeDebug() throws {
@@ -106,8 +100,6 @@ extension MCPInterfaceTests {
         let data = "[\"unknown\"]".data(using: .utf8)!
         #expect(throws: DecodingError.self) { try JSONDecoder().decode([LoggingLevel].self, from: data) }
       }
-
-      // MARK: Private
 
       private func testDecoding(of json: String, _ value: LoggingLevel) throws {
         // wrap the value in array for it to be valid JSON

--- a/MCPInterface/Tests/interface/PromptOrResourceReferenceTests.swift
+++ b/MCPInterface/Tests/interface/PromptOrResourceReferenceTests.swift
@@ -5,8 +5,6 @@ import Testing
 extension MCPInterfaceTests {
   struct PromptOrResourceReferenceTest {
 
-    // MARK: Internal
-
     @Test
     func encodePrompt() throws {
       let value = PromptOrResourceReference.prompt(.init(name: "code_review"))
@@ -28,8 +26,6 @@ extension MCPInterfaceTests {
         }
         """)
     }
-
-    // MARK: Private
 
     private func testEncoding(of value: PromptOrResourceReference, _ json: String) throws {
       try testEncodingOf(value, json)

--- a/MCPInterface/Tests/interface/RoleTests.swift
+++ b/MCPInterface/Tests/interface/RoleTests.swift
@@ -6,8 +6,6 @@ extension MCPInterfaceTests {
   enum RoleTest {
     struct Deserialization {
 
-      // MARK: Internal
-
       @Test
       func decodeUser() throws {
         #expect(try decode("\"user\"") == .user)
@@ -22,8 +20,6 @@ extension MCPInterfaceTests {
       func failsToDecodeBadValue() throws {
         #expect(throws: DecodingError.self) { try decode("\"bot\"") }
       }
-
-      // MARK: Private
 
       private func decode(_ json: String) throws -> Role {
         // wrap the value in array for it to be valid JSON

--- a/MCPInterface/Tests/interface/SerializationDeserializationTestUtils.swift
+++ b/MCPInterface/Tests/interface/SerializationDeserializationTestUtils.swift
@@ -53,7 +53,7 @@ func testDecodingOf<T: Decodable & Equatable>(_ value: T, _ json: String) throws
 }
 
 /// Test that encoding the value gives the expected json, and that decoding the json gives the expected value.
-func testEncodingDecoding<T: Codable & Equatable>(of value: T, _ json: String) throws {
+func testEncodingDecoding(of value: some Codable & Equatable, _ json: String) throws {
   try testEncodingOf(value, json)
   try testDecodingOf(value, json)
 }

--- a/MCPInterface/Tests/interface/ServerNotificationTests.swift
+++ b/MCPInterface/Tests/interface/ServerNotificationTests.swift
@@ -8,8 +8,6 @@ extension MCPInterfaceTests {
 
     struct Deserialization {
 
-      // MARK: Internal
-
       @Test
       func decodeCancelledNotification() throws {
         try testDecoding(
@@ -133,8 +131,6 @@ extension MCPInterfaceTests {
           """.data(using: .utf8)!
         #expect(throws: DecodingError.self) { try JSONDecoder().decode(ServerNotification.self, from: data) }
       }
-
-      // MARK: Private
 
       private func testDecoding(of json: String, _ value: ServerNotification) throws {
         let data = json.data(using: .utf8)!

--- a/MCPInterface/Tests/interface/ServerRequestTests.swift
+++ b/MCPInterface/Tests/interface/ServerRequestTests.swift
@@ -8,8 +8,6 @@ extension MCPInterfaceTests {
 
     struct Deserialization {
 
-      // MARK: Internal
-
       @Test
       func decodeCancelledNotification() throws {
         try testDecoding(
@@ -64,8 +62,6 @@ extension MCPInterfaceTests {
             systemPrompt: "You are a helpful assistant.",
             maxTokens: 100)))
       }
-
-      // MARK: Private
 
       private func testDecoding(of json: String, _ value: ServerRequest) throws {
         let data = json.data(using: .utf8)!

--- a/MCPInterface/Tests/interface/TextContentOrImageContentOrEmbeddedResourceTests.swift
+++ b/MCPInterface/Tests/interface/TextContentOrImageContentOrEmbeddedResourceTests.swift
@@ -6,8 +6,6 @@ import Testing
 extension MCPInterfaceTests {
   struct TextContentOrImageContentOrEmbeddedResourceTest {
 
-    // MARK: Internal
-
     @Test
     func decodeText() throws {
       let json = """
@@ -54,8 +52,6 @@ extension MCPInterfaceTests {
       #expect(value.embeddedResource?.resource.text?.uri == "resource://example")
       try testEncodingDecoding(of: value, json)
     }
-
-    // MARK: Private
 
     private func decode(_ jsonString: String) throws -> TextContentOrImageContentOrEmbeddedResource {
       let data = jsonString.data(using: .utf8)!

--- a/MCPInterface/Tests/interface/TextOrBlobResourceContentsTests.swift
+++ b/MCPInterface/Tests/interface/TextOrBlobResourceContentsTests.swift
@@ -6,8 +6,6 @@ import Testing
 extension MCPInterfaceTests {
   struct TextOrBlobResourceContentsTest {
 
-    // MARK: Internal
-
     @Test
     func decodeText() throws {
       let json = """
@@ -37,8 +35,6 @@ extension MCPInterfaceTests {
       #expect(value.blob?.blob == "base64-encoded-data")
       try testEncodingDecoding(of: value, json)
     }
-
-    // MARK: Private
 
     private func decode(_ jsonString: String) throws -> TextOrBlobResourceContents {
       let data = jsonString.data(using: .utf8)!

--- a/MCPInterface/Tests/interface/TextOrImageContentTests.swift
+++ b/MCPInterface/Tests/interface/TextOrImageContentTests.swift
@@ -7,8 +7,6 @@ extension MCPInterfaceTests {
   enum TextOrImageContentTest {
     struct Deserialization {
 
-      // MARK: Internal
-
       @Test
       func decodeText() throws {
         let value = try decode("""
@@ -49,8 +47,6 @@ extension MCPInterfaceTests {
             """)
         }
       }
-
-      // MARK: Private
 
       private func decode(_ jsonString: String) throws -> TextOrImageContent {
         let data = jsonString.data(using: .utf8)!

--- a/MCPServer/Sources/Convenience/Schemable+extensions.swift
+++ b/MCPServer/Sources/Convenience/Schemable+extensions.swift
@@ -35,8 +35,6 @@ public protocol CallableTool {
 
 public struct Tool<Input>: CallableTool {
 
-  // MARK: Lifecycle
-
   public init(
     name: String,
     description: String? = nil,
@@ -50,8 +48,6 @@ public struct Tool<Input>: CallableTool {
     _decodeInput = decodeInput
     _call = call
   }
-
-  // MARK: Public
 
   public let name: String
 
@@ -67,8 +63,6 @@ public struct Tool<Input>: CallableTool {
     let data = try JSONEncoder().encode(input)
     return try _decodeInput(data)
   }
-
-  // MARK: Private
 
   private let _call: (Input) async throws -> [TextContentOrImageContentOrEmbeddedResource]
 
@@ -157,7 +151,7 @@ extension JSONSchema_JSONValue {
     case .string(let value):
       .string(value)
     case .array(let value):
-      .array(value.map { $0.value })
+      .array(value.map(\.value))
     case .object(let value):
       .object(value.mapValues { $0.value })
     case .integer(let value):

--- a/MCPServer/Sources/MCPServerConnection.swift
+++ b/MCPServer/Sources/MCPServerConnection.swift
@@ -6,8 +6,6 @@ import MCPInterface
 
 public actor MCPServerConnection: MCPServerConnectionInterface {
 
-  // MARK: Lifecycle
-
   public init(
     info: Implementation,
     capabilities: ServerCapabilities,
@@ -19,8 +17,6 @@ public actor MCPServerConnection: MCPServerConnectionInterface {
     self.info = info
     self.capabilities = capabilities
   }
-
-  // MARK: Public
 
   public let info: Implementation
 
@@ -71,8 +67,6 @@ public actor MCPServerConnection: MCPServerConnectionInterface {
   public func log(_ params: LoggingMessageNotification.Params) async throws {
     try await jrpcSession.send(LoggingMessageNotification(params: params))
   }
-
-  // MARK: Private
 
   private let _connection: MCPConnection<ClientRequest, ClientNotification>
 

--- a/MCPServer/Sources/MCPServerInterface.swift
+++ b/MCPServer/Sources/MCPServerInterface.swift
@@ -62,8 +62,6 @@ public struct ListedCapabilityHandler<Info, Handler, ListHandler> {
 /// All the handler functions required to support the `resources` capability.
 public struct ResourcesCapabilityHandler {
 
-  // MARK: Lifecycle
-
   public init(
     listChanged: Bool = false,
     readResource: @escaping ReadResourceRequest.Handler,
@@ -81,8 +79,6 @@ public struct ResourcesCapabilityHandler {
     self.unsubscribeToResource = unsubscribeToResource
     self.complete = complete
   }
-
-  // MARK: Public
 
   /// Whether this server supports notifications for changes to the resource list.
   public let listChanged: Bool
@@ -120,7 +116,7 @@ extension MCPServerError: LocalizedError {
   public var errorDescription: String? {
     switch self {
     case .toolCallError(let errors):
-      return "Tool call error:\n\(errors.map { $0.localizedDescription }.joined(separator: "\n"))"
+      return "Tool call error:\n\(errors.map(\.localizedDescription).joined(separator: "\n"))"
     case .decodingError(let input, let schema):
       let encoder = JSONEncoder()
       encoder.outputFormatting = [.prettyPrinted, .sortedKeys]

--- a/MCPServer/Tests/MockMCPServerConnection.swift
+++ b/MCPServer/Tests/MockMCPServerConnection.swift
@@ -7,8 +7,6 @@ import MCPServer
 /// A mock `MCPServerConnection` that can be used in tests.
 class MockMCPServerConnection: MCPServerConnectionInterface {
 
-  // MARK: Lifecycle
-
   required init(
     info: Implementation,
     capabilities: ServerCapabilities,
@@ -30,8 +28,6 @@ class MockMCPServerConnection: MCPServerConnectionInterface {
     }
     self.sendRequestToStream = sendRequestToStream
   }
-
-  // MARK: Internal
 
   /// Send a client notification.
   private(set) var sendNotificationToStream: ((ClientNotification) -> Void) = { _ in }

--- a/MCPSharedTesting/Tests/CallToolTests.swift
+++ b/MCPSharedTesting/Tests/CallToolTests.swift
@@ -8,8 +8,6 @@ import Testing
 extension MCPConnectionTestSuite {
   final class CallToolTests: MCPConnectionTest {
 
-    // MARK: Internal
-
     @Test("call tool")
     func test_callTool() async throws {
       let weathers = try await assert(executing: {
@@ -20,7 +18,7 @@ extension MCPConnectionTestSuite {
           ]),
           progressToken: .string("toolCallId"))
           .content
-          .map { $0.text }
+          .map(\.text)
       }, triggers: [
         .clientSendsJrpc("""
           {
@@ -163,8 +161,6 @@ extension MCPConnectionTestSuite {
       #expect(response.isError == true)
       #expect(response.content.map { $0.text?.text } == ["Failed to fetch weather data: API rate limit exceeded"])
     }
-
-    // MARK: Private
 
     private let tool = Tool(
       name: "get_weather",

--- a/MCPSharedTesting/Tests/ListPromptTests.swift
+++ b/MCPSharedTesting/Tests/ListPromptTests.swift
@@ -60,7 +60,7 @@ extension MCPConnectionTestSuite {
             }
             """),
         ])
-      #expect(prompts.map { $0.name } == ["code_review"])
+      #expect(prompts.map(\.name) == ["code_review"])
     }
 
     @Test("list prompts with pagination")
@@ -164,7 +164,7 @@ extension MCPConnectionTestSuite {
             }
             """),
         ])
-      #expect(prompts.map { $0.name } == ["code_review", "test_code"])
+      #expect(prompts.map(\.name) == ["code_review", "test_code"])
     }
 
     @Test("receiving prompts list changed notification")

--- a/MCPSharedTesting/Tests/ListResourceTemplates.swift
+++ b/MCPSharedTesting/Tests/ListResourceTemplates.swift
@@ -51,7 +51,7 @@ extension MCPConnectionTestSuite {
             }
             """),
         ])
-      #expect(resources.map { $0.uriTemplate } == ["file:///{path}"])
+      #expect(resources.map(\.uriTemplate) == ["file:///{path}"])
     }
 
     @Test("list resource templates with pagination")
@@ -142,7 +142,7 @@ extension MCPConnectionTestSuite {
             }
             """),
         ])
-      #expect(resources.map { $0.uriTemplate } == ["file:///{path}", "images:///{path}"])
+      #expect(resources.map(\.uriTemplate) == ["file:///{path}", "images:///{path}"])
     }
 
   }

--- a/MCPSharedTesting/Tests/ListResourcesTest.swift
+++ b/MCPSharedTesting/Tests/ListResourcesTest.swift
@@ -52,7 +52,7 @@ extension MCPConnectionTestSuite {
             }
             """),
         ])
-      #expect(resources.map { $0.name } == ["main.rs"])
+      #expect(resources.map(\.name) == ["main.rs"])
     }
 
     @Test("list resources with pagination")
@@ -143,7 +143,7 @@ extension MCPConnectionTestSuite {
             }
             """),
         ])
-      #expect(resources.map { $0.name } == ["main.rs", "utils.rs"])
+      #expect(resources.map(\.name) == ["main.rs", "utils.rs"])
     }
 
     @Test("receiving resources list changed notification")

--- a/MCPSharedTesting/Tests/ListRootsTests.swift
+++ b/MCPSharedTesting/Tests/ListRootsTests.swift
@@ -45,7 +45,7 @@ extension MCPConnectionTestSuite {
             }
             """),
         ])
-      #expect(roots.roots.map { $0.name } == ["My Project"])
+      #expect(roots.roots.map(\.name) == ["My Project"])
     }
 
     @Test("receiving roots list changed notification")

--- a/MCPSharedTesting/Tests/ListToolsTests.swift
+++ b/MCPSharedTesting/Tests/ListToolsTests.swift
@@ -67,7 +67,7 @@ extension MCPConnectionTestSuite {
             }
             """),
         ])
-      #expect(tools.map { $0.name } == ["get_weather"])
+      #expect(tools.map(\.name) == ["get_weather"])
     }
 
     @Test("list tools with pagination")
@@ -188,7 +188,7 @@ extension MCPConnectionTestSuite {
             """),
         ])
 
-      #expect(tools.map { $0.name } == ["get_weather", "get_time"])
+      #expect(tools.map(\.name) == ["get_weather", "get_time"])
     }
 
     @Test("receiving list tool changed notification")

--- a/MCPSharedTesting/Tests/TestSuite.swift
+++ b/MCPSharedTesting/Tests/TestSuite.swift
@@ -16,8 +16,6 @@ class MCPConnectionTestSuite { }
 /// A parent test class that provides a few util functions to assert that the interactions with the transport are as expected.
 class MCPConnectionTest {
 
-  // MARK: Lifecycle
-
   init() {
     clientTransport = MockTransport()
     serverTransport = MockTransport()
@@ -47,8 +45,6 @@ class MCPConnectionTest {
     }
   }
 
-  // MARK: Internal
-
   var clientTransport: MockTransport
   var serverTransport: MockTransport
 
@@ -70,10 +66,10 @@ extension MCPConnectionTest {
     try await MCPTestingUtils.assert(
       clientTransport: clientTransport,
       serverTransport: serverTransport,
-      serverRequestsHandler: await clientConnection.requestsToHandle,
-      clientRequestsHandler: await serverConnection.requestsToHandle,
-      serverNotifications: await clientConnection.notifications,
-      clientNotifications: await serverConnection.notifications,
+      serverRequestsHandler: clientConnection.requestsToHandle,
+      clientRequestsHandler: serverConnection.requestsToHandle,
+      serverNotifications: clientConnection.notifications,
+      clientNotifications: serverConnection.notifications,
       executing: task,
       triggers: events)
   }

--- a/MCPTestingUtils/Sources/MockTransport.swift
+++ b/MCPTestingUtils/Sources/MockTransport.swift
@@ -8,8 +8,6 @@ import Testing
 
 public final class MockTransport {
 
-  // MARK: Lifecycle
-
   public init() {
     let dataSequence = AsyncStream<Data>() { continuation in
       self.continuation = continuation
@@ -20,9 +18,7 @@ public final class MockTransport {
       dataSequence: dataSequence)
   }
 
-  // MARK: Public
-
-  public private(set) var dataChannel: DataChannel = .noop
+  public private(set) var dataChannel = DataChannel.noop
 
   public func onSendMessage(_ hook: @escaping (Data) -> Void) {
     let previousSendMessage = sendMessage
@@ -36,8 +32,6 @@ public final class MockTransport {
     let data = Data(message.utf8)
     continuation?.yield(data)
   }
-
-  // MARK: Private
 
   private var sendMessage: (Data) -> Void = { _ in }
 

--- a/MCPTestingUtils/Sources/TestUtils.swift
+++ b/MCPTestingUtils/Sources/TestUtils.swift
@@ -161,9 +161,9 @@ public func assert<Result>(
       let exp = expectation(description: "clientResponding completed (event #\(i))")
       expectations.append(exp)
       Task {
-        for await(request, completion) in serverRequestsHandler {
+        for await (request, completion) in serverRequestsHandler {
           do {
-            completion(try await requestHandler(request))
+            try await completion(requestHandler(request))
           } catch {
             Issue.record(error)
           }
@@ -179,9 +179,9 @@ public func assert<Result>(
       let exp = expectation(description: "serverResponding completed (event #\(i))")
       expectations.append(exp)
       Task {
-        for await(request, completion) in clientRequestsHandler {
+        for await (request, completion) in clientRequestsHandler {
           do {
-            completion(try await requestHandler(request))
+            try await completion(requestHandler(request))
           } catch {
             Issue.record(error)
           }

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "0330db019e2fd99f9afeae2563867fe78b6e741a0dffec856c844843684b3472",
+  "originHash" : "ca8a2b4edc1c41afb8ecd936a019651205225b4a18838bc0cf477f9c76a577ae",
   "pins" : [
     {
       "identity" : "jsonrpc",
@@ -8,24 +8,6 @@
       "state" : {
         "revision" : "56c936de4e4385287dc18f260557dbdf443a55bd",
         "version" : "0.9.1"
-      }
-    },
-    {
-      "identity" : "swift",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/airbnb/swift",
-      "state" : {
-        "revision" : "fa3ae574d0b9c93a1655424bd4381044274c5cb4",
-        "version" : "1.0.7"
-      }
-    },
-    {
-      "identity" : "swift-argument-parser",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-argument-parser",
-      "state" : {
-        "revision" : "41982a3656a71c768319979febd796c6fd111d5c",
-        "version" : "1.5.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -30,8 +30,6 @@ let package = Package(
     .package(url: "https://github.com/gsabran/JSONRPC", from: "0.9.1"),
     .package(url: "https://github.com/gohanlon/swift-memberwise-init-macro", from: "0.5.1"),
     .package(url: "https://github.com/ajevans99/swift-json-schema", from: "0.3.1"),
-    // Dev dependency
-    .package(url: "https://github.com/airbnb/swift", from: "1.0.0"),
   ],
   targets: [
     .target(

--- a/SwiftTestingUtils/Sources/SwiftTestingUtils.swift
+++ b/SwiftTestingUtils/Sources/SwiftTestingUtils.swift
@@ -9,11 +9,7 @@ private let logger = Logger(subsystem: "testing", category: "testing")
 
 public enum SwiftTestingUtils {
 
-  // MARK: Public
-
   public class Expectation {
-
-    // MARK: Lifecycle
 
     init(
       description: String,
@@ -23,8 +19,6 @@ public enum SwiftTestingUtils {
       location = _sourceLocation
     }
 
-    // MARK: Public
-
     public func fulfill() {
       if isFulfilled {
         Issue.record("Expectation from \(location) already fulfilled.")
@@ -32,8 +26,6 @@ public enum SwiftTestingUtils {
       isFulfilled = true
       onFulfill()
     }
-
-    // MARK: Internal
 
     private(set) var isFulfilled = false
 
@@ -47,7 +39,7 @@ public enum SwiftTestingUtils {
 
       var hasTimedOut = false
       var hasCompleted = false
-      let description = self.description
+      let description = description
 
       try await withCheckedThrowingContinuation { continuation in
         onFulfill = {
@@ -72,12 +64,8 @@ public enum SwiftTestingUtils {
       }
     }
 
-    // MARK: Private
-
     private var onFulfill: () -> Void = { }
   }
-
-  // MARK: Internal
 
   enum SwiftTesting: Error {
     case expectationTimeout(description: String)

--- a/rules.swiftformat
+++ b/rules.swiftformat
@@ -1,0 +1,132 @@
+# copied from https://github.com/airbnb/swift/blob/master/Sources/AirbnbSwiftFormatTool/airbnb.swiftformat
+
+# Exclude checkout directories for common package managers
+--exclude Carthage,Pods,.build
+
+# options
+--swiftversion 6.0
+--languagemode 5
+--self remove # redundantSelf
+--importgrouping testable-bottom # sortedImports
+--commas always # trailingCommas
+--trimwhitespace always # trailingSpace
+--indent 2 #indent
+--ifdef no-indent #indent
+--indentstrings true #indent
+--wraparguments before-first # wrapArguments
+--wrapparameters before-first # wrapArguments
+--wrapcollections before-first # wrapArguments
+--wrapconditions before-first # wrapArguments
+--wrapreturntype if-multiline #wrapArguments
+--wrapeffects if-multiline #wrapArguments
+--closingparen same-line # wrapArguments
+--wraptypealiases before-first # wrapArguments
+--funcattributes prev-line # wrapAttributes
+--computedvarattrs prev-line # wrapAttributes
+--storedvarattrs same-line # wrapAttributes
+--complexattrs prev-line # wrapAttributes
+--typeattributes prev-line # wrapAttributes
+--wrapternary before-operators # wrap
+--structthreshold 20 # organizeDeclarations
+--enumthreshold 20 # organizeDeclarations
+--organizetypes class,struct,enum,extension,actor # organizeDeclarations
+--visibilityorder beforeMarks,instanceLifecycle,open,public,package,internal,fileprivate,private # organizeDeclarations
+--typeorder nestedType,staticProperty,staticPropertyWithBody,classPropertyWithBody,swiftUIPropertyWrapper,instanceProperty,instancePropertyWithBody,staticMethod,classMethod,instanceMethod # organizeDeclarations
+# --sortswiftuiprops first-appearance-sort #organizeDeclarations
+--extensionacl on-declarations # extensionAccessControl
+--patternlet inline # hoistPatternLet
+--propertytypes inferred # redundantType, propertyTypes
+--typeblanklines preserve # blankLinesAtStartOfScope, blankLinesAtEndOfScope
+--emptybraces spaced # emptyBraces
+--ranges preserve # spaceAroundOperators
+--operatorfunc no-space # spaceAroundOperators
+--someAny disabled # opaqueGenericParameters
+--elseposition same-line # elseOnSameLine
+--guardelse next-line # elseOnSameLine
+--onelineforeach convert # preferForLoop
+--shortoptionals always # typeSugar
+--semicolons never # semicolons
+--doccomments preserve # docComments
+--markcategories false
+
+# We recommend a max width of 100 but _strictly enforce_ a max width of 130
+--maxwidth 130 # wrap
+
+# rules
+--rules anyObjectProtocol
+--rules blankLinesBetweenScopes
+--rules consecutiveSpaces
+--rules consecutiveBlankLines
+--rules duplicateImports
+--rules extensionAccessControl
+# --rules environmentEntry
+--rules hoistPatternLet
+--rules indent
+--rules markTypes
+--rules organizeDeclarations
+--rules redundantParens
+--rules redundantReturn
+--rules redundantSelf
+--rules redundantType
+--rules redundantPattern
+--rules redundantGet
+--rules redundantFileprivate
+--rules redundantRawValues
+# --rules redundantEquatable
+--rules sortImports
+--rules sortDeclarations
+--rules strongifiedSelf
+--rules trailingCommas
+--rules trailingSpace
+--rules linebreakAtEndOfFile
+--rules typeSugar
+--rules wrap
+--rules wrapMultilineStatementBraces
+--rules wrapArguments
+--rules wrapAttributes
+--rules braces
+--rules redundantClosure
+--rules redundantInit
+--rules redundantVoidReturnType
+--rules redundantOptionalBinding
+--rules redundantInternal
+--rules redundantProperty
+--rules unusedArguments
+--rules spaceInsideBrackets
+--rules spaceInsideBraces
+--rules spaceAroundBraces
+--rules spaceInsideParens
+--rules spaceAroundParens
+--rules spaceAroundOperators
+--rules enumNamespaces
+--rules blockComments
+--rules docComments
+--rules docCommentsBeforeModifiers
+--rules spaceAroundComments
+--rules spaceInsideComments
+--rules blankLinesAtStartOfScope
+--rules blankLinesAtEndOfScope
+--rules emptyBraces
+--rules hoistAwait
+--rules hoistTry
+--rules hoistPatternLet
+--rules andOperator
+--rules opaqueGenericParameters
+# --rules genericExtensions
+--rules trailingClosures
+--rules elseOnSameLine
+--rules sortTypealiases
+--rules preferForLoop
+--rules conditionalAssignment
+--rules wrapMultilineConditionalAssignment
+--rules void
+--rules blankLineAfterSwitchCase
+--rules consistentSwitchCaseSpacing
+--rules semicolons
+--rules propertyTypes
+--rules blankLinesBetweenChainedFunctions
+--rules leadingDelimiters
+--rules preferKeyPath
+# --rules unusedPrivateDeclarations
+# --rules emptyExtensions
+# --rules preferCountWhere


### PR DESCRIPTION
## Summary
Rework lint, and switch to `swiftformat` instead of a local package that is less configurable.

Most changes come from running `swiftformat --config rules.swiftformat .`