### PR TITLE
Process+extensions.swift and DataChannel+StdioProcess.swift are chang…

### DIFF
--- a/MCPClient/Sources/Process+extensions.swift
+++ b/MCPClient/Sources/Process+extensions.swift
@@ -3,11 +3,14 @@
 
 import Foundation
 
+// MARK: - Process Extensions (macOS only)
+
+#if os(macOS)
 extension Process {
   /// Launches process.
   ///
   /// - throws: CommandError.inAccessibleExecutable if command could not be executed.
-  func launchThrowably() throws {
+  public func launchThrowably() throws {
     #if !os(macOS)
     guard Files.isExecutableFile(atPath: executableURL!.path) else {
       throw CommandError.inAccessibleExecutable(path: executableURL!.lastPathComponent)
@@ -32,7 +35,7 @@ extension Process {
   ///
   /// - throws: `CommandError.returnedErrorCode(command: String, errorcode: Int)`
   ///   if the exit code is anything but 0.
-  func finish() throws {
+  public func finish() throws {
     /// The full path to the executable + all arguments, each one quoted if it contains a space.
     func commandAsString() -> String {
       let path: String =
@@ -51,6 +54,7 @@ extension Process {
     }
   }
 }
+#endif
 
 // MARK: - CommandError
 

--- a/MCPClient/Sources/stdioTransport/DataChannel+StdioProcess.swift
+++ b/MCPClient/Sources/stdioTransport/DataChannel+StdioProcess.swift
@@ -44,7 +44,9 @@ extension JSONRPCSetupError: LocalizedError {
 
 extension Transport {
 
+#if os(macOS)
   /// Creates a new `Transport` by launching the given executable with the specified arguments and attaching to its standard IO.
+  /// This functionality is only available on macOS.
   public static func stdioProcess(
     _ executable: String,
     args: [String] = [],
@@ -105,6 +107,7 @@ extension Transport {
   }
 
   /// Creates a new `Transport` by launching the given process and attaching to its standard IO.
+  /// This functionality is only available on macOS.
   public static func stdioProcess(
     unlaunchedProcess process: Process,
     verbose: Bool = false)
@@ -193,6 +196,7 @@ extension Transport {
   }
 
   /// Finds the full path to the executable using the `which` command.
+  /// This functionality is only available on macOS.
   private static func locate(executable: String, env: [String: String]? = nil) throws -> String {
     let process = Process()
     process.executableURL = URL(fileURLWithPath: "/usr/bin/which")
@@ -209,6 +213,8 @@ extension Transport {
     return executablePath
   }
 
+  /// Loads the zsh environment variables.
+  /// This functionality is only available on macOS.
   private static func loadZshEnvironment(userEnv: [String: String]? = nil) throws -> [String: String] {
     // Load shell environment as base
     let shellProcess = Process()
@@ -246,6 +252,8 @@ extension Transport {
       }
   }
 
+  /// Gets the standard output from a process.
+  /// This functionality is only available on macOS.
   private static func getProcessStdout(process: Process) throws -> String? {
     let stdout = Pipe()
     let stderr = Pipe()
@@ -278,7 +286,7 @@ extension Transport {
 
     return String(data: stdoutData, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines)
   }
-
+#endif
 }
 
 // MARK: - Lifetime


### PR DESCRIPTION
…ed to make the Process-dependent functionality only available on platforms where the API exists.

## Summary

This PR addresses platform compatibility issues with the Process class by using Swift's conditional compilation to make Process-dependent functionality only available on macOS. This approach leverages compile-time safety rather than runtime errors, resulting in cleaner and more maintainable code.

## Details

### Changes

- Used #if os(macOS) conditional compilation directives to restrict Process-dependent code to macOS
- Added clear documentation indicating which functions are only available on macOS
- Removed unnecessary stub implementations for iOS

### Technical Details

- Modified Process+extensions.swift to conditionally compile Process extensions only for macOS
- Updated DataChannel+StdioProcess.swift to wrap all Process-dependent functionality in platform-specific directives
- Added proper documentation comments indicating platform availability restrictions
- Kept error types accessible across platforms for consistent error handling

